### PR TITLE
chore: add root test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "dev": "concurrently -k -n WEB,API -c green,cyan \"pnpm --filter web dev\" \"pnpm --filter server dev\"",
     "build": "pnpm -r build",
-    "start": "pnpm --filter server start"
+    "start": "pnpm --filter server start",
+    "test": "pnpm -r test"
   },
   "devDependencies": {
     "concurrently": "^9.0.0"


### PR DESCRIPTION
## Summary
- add root `test` script to run tests recursively in all workspaces

## Testing
- `pnpm test --workspaces=false` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68abdfc589948329a5e958f7b7d9b8f7