### PR TITLE
chore(web): add react plugin dev dependency

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
     "typescript": "^5.5.4",
     "vite": "^5.4.2"
   }


### PR DESCRIPTION
## Summary
- add `@vitejs/plugin-react` to web devDependencies

## Testing
- `pnpm --filter web install` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz; Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm --filter web build` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz; Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68abdef134508329ac1d41a0ca373e35