### PR TITLE
chore: add test scripts and sample tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "dev": "concurrently -k -n WEB,API -c green,cyan \"pnpm --filter web dev\" \"pnpm --filter server dev\"",
     "build": "pnpm -r build",
-    "start": "pnpm --filter server start"
+    "start": "pnpm --filter server start",
+    "test": "pnpm -r test"
   },
   "devDependencies": {
     "concurrently": "^9.0.0"

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc -p tsconfig.json",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "node --import tsx --test"
   },
   "dependencies": {
     "axios": "^1.7.2",

--- a/server/src/example.test.ts
+++ b/server/src/example.test.ts
@@ -1,0 +1,8 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+describe('placeholder', () => {
+  it('adds numbers', () => {
+    assert.strictEqual(1 + 1, 2);
+  });
+});

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview --port 5173"
+    "preview": "vite preview --port 5173",
+    "test": "vitest run"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -16,6 +17,7 @@
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "typescript": "^5.5.4",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^1.6.0"
   }
 }

--- a/web/src/example.test.ts
+++ b/web/src/example.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('placeholder', () => {
+  it('adds numbers', () => {
+    expect(1 + 1).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add root `pnpm -r test` script
- wire up Node and Vitest test scripts for packages
- include minimal test files to exercise runners

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `node --import tsx --test server/src/example.test.ts`
- `npx vitest run web/src/example.test.ts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68abded73b2083299e3ee919ed538f9c