### PR TITLE
feat: wire copy module and seo content

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,11 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>CA Plate Genie</title>
+  <title>CA Plate Helper — Generate Vanity Plate Ideas & Check Availability (California)</title>
+  <meta name="description" content="Generate short, catchy California vanity plate ideas with AI and check availability fast. Filter by length, allow numbers, save favorites, and jump straight to the DMV order page." />
+  <meta property="og:title" content="CA Plate Helper — Find a plate you’ll actually get" />
+  <meta property="og:description" content="Type a seed, get tight 2–7 character ideas, check California availability, and save favorites." />
+  <meta property="og:type" content="website" />
   <link rel="stylesheet" href="/src/ui.css" />
 </head>
 <body>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from "react";
 import { apiSuggest, apiCheck } from "./api";
 import type { Availability } from "./types";
+import { COPY } from "./copy";
 
 type Row = { plate: string; availability?: Availability; checking?: boolean; };
 
@@ -58,41 +59,93 @@ export default function App() {
   };
 
   const badge = (a?: Availability) => {
-    if (!a) return <span className="badge gray">unchecked</span>;
+    if (!a) return <span className="badge gray">{COPY.STATUS.unchecked}</span>;
     const cls = a === "AVAILABLE" ? "badge green" : a === "TAKEN" ? "badge red" : "badge gray";
-    return <span className={cls}>{a.toLowerCase()}</span>;
+    const txt =
+      a === "AVAILABLE"
+        ? COPY.STATUS.available
+        : a === "TAKEN"
+        ? COPY.STATUS.taken
+        : a === "INVALID"
+        ? COPY.STATUS.invalid
+        : COPY.STATUS.unknown;
+    return <span className={cls}>{txt}</span>;
   };
 
   return (
     <div className="container">
       <img src="/CA-Plate-Genie.gif" alt="Driving genie" className="hero" />
-      <h1>CA Plate Genie</h1>
-      <p><small className="hint">Generate ideas and test availability for California personalized plates.</small></p>
+      <h1>{COPY.HERO.headline}</h1>
+      <p><small className="hint">{COPY.HERO.subhead}</small></p>
 
       <div className="row">
-        <input value={seed} onChange={e => setSeed(e.target.value)} placeholder="Seed (e.g., 'fast', 'ai', 'duncan')" />
-        <select value={min} onChange={e => setMin(Number(e.target.value))}>
-          {[2,3,4,5,6,7].map(n => <option key={n} value={n}>min {n}</option>)}
-        </select>
-        <select value={max} onChange={e => setMax(Number(e.target.value))}>
-          {[2,3,4,5,6,7].map(n => <option key={n} value={n}>max {n}</option>)}
-        </select>
-        <label><input type="checkbox" checked={allowNumbers} onChange={e => setAllowNumbers(e.target.checked)} /> allow numbers</label>
-        <button disabled={!canGen} onClick={generate}>{busy ? "Generating..." : "Generate"}</button>
+        <input
+          value={seed}
+          onChange={e => setSeed(e.target.value)}
+          placeholder={COPY.INPUT.placeholder}
+          title={COPY.TOOLTIPS.seed}
+        />
+        <label title={COPY.TOOLTIPS.min}>
+          {COPY.INPUT.minLabel}
+          <select value={min} onChange={e => setMin(Number(e.target.value))}>
+            {[2, 3, 4, 5, 6, 7].map(n => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label title={COPY.TOOLTIPS.max}>
+          {COPY.INPUT.maxLabel}
+          <select value={max} onChange={e => setMax(Number(e.target.value))}>
+            {[2, 3, 4, 5, 6, 7].map(n => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label title={COPY.TOOLTIPS.allowNumbers}>
+          <input
+            type="checkbox"
+            checked={allowNumbers}
+            onChange={e => setAllowNumbers(e.target.checked)}
+          />
+          {" "}
+          {COPY.INPUT.allowNumbers}
+        </label>
+        <button disabled={!canGen} onClick={generate}>
+          {busy ? COPY.INPUT.generating : COPY.INPUT.generate}
+        </button>
       </div>
 
+      {rows.length === 0 && !busy && (
+        <p>
+          <small className="hint">{COPY.EMPTY.suggestions}</small>
+        </p>
+      )}
       <div className="grid">
         {rows.map(r => (
           <div className="card" key={r.plate}>
             <div style={{ fontSize: 22, letterSpacing: 2 }}>{r.plate}</div>
-            <div>{badge(r.availability)} {r.checking ? "checking..." : ""}</div>
+            <div>
+              {badge(r.availability)} {r.checking ? "checking..." : ""}
+            </div>
             <div className="row" style={{ justifyContent: "center" }}>
-              <button onClick={() => checkOne(r.plate)}>Check</button>
-              {favs.includes(r.plate)
-                ? <button onClick={() => rmFav(r.plate)}>★ Saved</button>
-                : <button onClick={() => addFav(r.plate)}>☆ Save</button>}
-              <a href="https://www.google.com/search?q=California+DMV+Personalized+Plates+Order" target="_blank" rel="noreferrer">
-                <button>Order ▸</button>
+              <button onClick={() => checkOne(r.plate)} title={COPY.TOOLTIPS.check}>
+                {COPY.ACTIONS.check}
+              </button>
+              {favs.includes(r.plate) ? (
+                <button onClick={() => rmFav(r.plate)} title={COPY.TOOLTIPS.save}>
+                  {COPY.ACTIONS.saved}
+                </button>
+              ) : (
+                <button onClick={() => addFav(r.plate)} title={COPY.TOOLTIPS.save}>
+                  {COPY.ACTIONS.save}
+                </button>
+              )}
+              <a href={COPY.LINKS.dmvOrder} target="_blank" rel="noreferrer">
+                <button title={COPY.TOOLTIPS.order}>{COPY.ACTIONS.order}</button>
               </a>
             </div>
           </div>
@@ -102,11 +155,58 @@ export default function App() {
       <hr />
       <h2>Favorites</h2>
       <div className="favs row" style={{ gap: 6 }}>
-        {orderedFavs.length === 0 && <small className="hint">No favorites saved yet.</small>}
+        {orderedFavs.length === 0 && (
+          <small className="hint">{COPY.EMPTY.favorites}</small>
+        )}
         {orderedFavs.map(p => (
-          <span key={p} className="badge gray">{p} <button onClick={() => rmFav(p)}>×</button></span>
+          <span key={p} className="badge gray">
+            {p} <button onClick={() => rmFav(p)}>×</button>
+          </span>
         ))}
       </div>
+      <hr />
+      <h2>{COPY.HOW_IT_WORKS.title}</h2>
+      <ol>
+        {COPY.HOW_IT_WORKS.steps.map(s => (
+          <li key={s}>{s}</li>
+        ))}
+      </ol>
+      <h2>{COPY.TIPS.title}</h2>
+      <ul>
+        {COPY.TIPS.bullets.map(b => (
+          <li key={b}>{b}</li>
+        ))}
+      </ul>
+      <h2>{COPY.RULES.title}</h2>
+      <ul>
+        {COPY.RULES.bullets.map(b => (
+          <li key={b}>{b}</li>
+        ))}
+      </ul>
+      <p>
+        <small className="hint">{COPY.HINTS.keyboard}</small>
+      </p>
+      <h2>{COPY.FAQ.title}</h2>
+      <div>
+        {COPY.FAQ.items.map(i => (
+          <details key={i.q}>
+            <summary>{i.q}</summary>
+            <p>{i.a}</p>
+          </details>
+        ))}
+      </div>
+      <hr />
+      <footer>
+        <p>
+          <small>{COPY.FOOTER.line1}</small>
+        </p>
+        <p>
+          <small>{COPY.FOOTER.line2}</small>
+        </p>
+        <p>
+          <small>{COPY.FOOTER.copyright}</small>
+        </p>
+      </footer>
     </div>
   );
 }

--- a/web/src/copy.en.ts
+++ b/web/src/copy.en.ts
@@ -1,0 +1,136 @@
+export const SEO = {
+  title: "CA Plate Helper — Generate Vanity Plate Ideas & Check Availability (California)",
+  description:
+    "Generate short, catchy California vanity plate ideas with AI and check availability fast. Filter by length, allow numbers, save favorites, and jump straight to the DMV order page.",
+  ogTitle: "CA Plate Helper — Find a plate you’ll actually get",
+  ogDescription:
+    "Type a seed, get tight 2–7 character ideas, check California availability, and save favorites."
+};
+
+export const HERO = {
+  headline: "Find a plate you’ll actually get.",
+  subhead:
+    "Type a seed word. We’ll generate tight, 2–7 character plates and check California availability in seconds.",
+  ctaPrimary: "Generate ideas",
+  ctaSecondary: "See how it works"
+};
+
+export const INPUT = {
+  placeholder: "Seed a theme or name (e.g., FAST, AI, SURF, GROW)",
+  minLabel: "Min length",
+  maxLabel: "Max length",
+  allowNumbers: "Allow numbers",
+  generate: "Generate",
+  generating: "Generating…"
+};
+
+export const STATUS = {
+  unchecked: "unchecked",
+  available: "available",
+  taken: "taken",
+  invalid: "not allowed",
+  unknown: "unknown"
+};
+
+export const ACTIONS = {
+  check: "Check",
+  save: "☆ Save",
+  saved: "★ Saved",
+  order: "Order ▸"
+};
+
+export const HOW_IT_WORKS = {
+  title: "How it works",
+  steps: [
+    "Seed — Enter a word or two.",
+    "Generate — AI + rules propose 2–7 character plates.",
+    "Filter — Adjust min/max and numbers.",
+    "Check — Verify California availability.",
+    "Save — Star your favorites.",
+    "Order — Jump to the DMV flow."
+  ]
+};
+
+export const TIPS = {
+  title: "Quick tips",
+  bullets: [
+    "Short wins: 4–6 characters read best.",
+    "Drop vowels (GRWTH). Use numerals sparingly (E→3, O→0).",
+    "Avoid ambiguous 1/I and 0/O unless intentional.",
+    "“Not allowed” usually means a blocked or disguised offending pattern."
+  ]
+};
+
+export const RULES = {
+  title: "California basics",
+  bullets: [
+    "Length: 2–7 characters (A–Z, 0–9).",
+    "No spaces or punctuation.",
+    "Some words/substitutions are restricted.",
+    "Availability can change; order quickly if you love it."
+  ]
+};
+
+export const EMPTY = {
+  suggestions: "Start with a seed word to generate plate ideas.",
+  favorites: "Tap ☆ on any plate to save it here."
+};
+
+export const ERRORS = {
+  invalidInput: "Use A–Z and 0–9 only, 2–7 characters.",
+  rateLimited: "Too many requests. Try again in a minute.",
+  dmvUnknown: "The DMV didn’t return a clear result. Try again or pick another idea.",
+  scrapeOff: "Live checks are off. Using mock availability."
+};
+
+export const HINTS = {
+  keyboard: "Shortcuts: Enter (generate), C (check), S (save)"
+};
+
+export const FAQ = {
+  title: "FAQ",
+  items: [
+    {
+      q: "How accurate is the availability?",
+      a: "We simulate the DMV’s check and classify the response. Results are near-real-time but not official until you complete the DMV order."
+    },
+    {
+      q: "Do you place the order for me?",
+      a: "No. We send you to the DMV ordering page to complete purchase."
+    },
+    {
+      q: "Why is a plate “not allowed”?",
+      a: "California blocks offensive or confusing patterns. We pre-filter with a conservative list and fuzzy matching."
+    },
+    {
+      q: "Will you support other states?",
+      a: "Yes, the engine is adapter-based and more states are planned."
+    },
+    {
+      q: "Do you store my plates?",
+      a: "We cache recent checks (≈15 minutes) for speed. Favorites are stored locally in your browser."
+    }
+  ]
+};
+
+export const FOOTER = {
+  line1: "Not affiliated with the California DMV. Availability can change at any time.",
+  line2: "Order on the DMV site to finalize your plate.",
+  copyright: `“CA Plate Helper” © ${new Date().getFullYear()}. All rights reserved.`
+};
+
+export const TOOLTIPS = {
+  seed: "A short word or theme to inspire ideas (e.g., RUN, AI, SURF).",
+  min: "Minimum characters for suggestions (2–7).",
+  max: "Maximum characters for suggestions (2–7).",
+  allowNumbers: "Toggle numeric substitutions and digits in results.",
+  check: "Query the DMV and classify availability.",
+  save: "Pin this plate to your favorites.",
+  order: "Open the DMV ordering page in a new tab."
+};
+
+export const LINKS = {
+  dmvOrder:
+    "https://www.google.com/search?q=California+DMV+Personalized+Plates+Order"
+};
+

--- a/web/src/copy.ts
+++ b/web/src/copy.ts
@@ -1,0 +1,1 @@
+export * as COPY from "./copy.en";


### PR DESCRIPTION
## Summary
- centralize strings in new copy module
- render CA Plate Genie GIF with updated hero copy and tooltips
- add meta description and open graph tags for SEO

## Testing
- `npm test --workspaces=false`
- `cd server && npm test`
- `npm run build` (server)
- `cd web && npm test`
- `npm run build` (web)


------
https://chatgpt.com/codex/tasks/task_e_68abdcebb40c83299833bc689e31f597