### PR TITLE
Enable synthetic default imports

### DIFF
--- a/server/src/cache.ts
+++ b/server/src/cache.ts
@@ -1,7 +1,7 @@
-import LRU from "lru-cache";
+import { LRUCache } from "lru-cache";
 
-export function makeTTLCache<T>(ttlMinutes: number) {
-  return new LRU<string, T>({
+export function makeTTLCache<T extends object>(ttlMinutes: number) {
+  return new LRUCache<string, T>({
     ttl: ttlMinutes * 60 * 1000,
     max: 5000,
   });

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,6 +5,7 @@
     "module": "NodeNext",
     "strict": true,
     "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "resolveJsonModule": true
   }


### PR DESCRIPTION
## Summary
- Allow synthetic default imports in the base tsconfig
- Fix LRU cache import and typing in server cache helper

## Testing
- `pnpm --filter server build` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `npx tsc -p server/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68abdedf423c832980762e76cc5cc74c