### PR TITLE
Add Vitest setup with sample React test

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -6,16 +6,20 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview --port 5173"
+    "preview": "vite preview --port 5173",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@testing-library/react": "^14.2.2",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "jsdom": "^24.0.0",
     "typescript": "^5.5.4",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^1.6.0"
   }
 }

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import App from './App';
+
+describe('App', () => {
+  it('renders heading', () => {
+    render(<App />);
+    const heading = screen.getByRole('heading', { name: /CA Plate Genie/i });
+    expect(heading).toBeDefined();
+  });
+});

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- add Vitest and Testing Library dependencies to web package
- configure Vitest with React plugin and jsdom environment
- include sample App component test

## Testing
- `pnpm --filter web test` *(fails: Error when performing request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68abdf053498832989a1623625f2b3d7