### PR TITLE
feat: allow external API base and configure pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,11 @@ Minimal app to generate catchy California vanity plate ideas and check availabil
 ## Notes
 - If `HUGGING_FACE_API_KEY` is not set, suggestions still work via the rule-based fallback.
 - `CA_DMV_MODE=mock` for local dev; switch to `scrape` and set selectors/regex for real checks.
+
+## Deployment
+
+- **GitHub Pages**: Vite is configured with `base: "/PlateGenieCA/"` so the built assets resolve
+  correctly when hosted under `https://<user>.github.io/PlateGenieCA/`.
+  Build the frontend with `pnpm --filter web build` and publish the contents of `web/dist`.
+- **Separate backend**: when the API lives on another host, set `VITE_API_BASE` in a `web/.env`
+  file (see `web/.env.example`). The frontend will prepend this value to `/api` requests.

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,3 @@
+# Base URL for API requests when the backend is hosted elsewhere.
+# Leave empty to use the same origin as the static site.
+VITE_API_BASE=

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,7 +1,10 @@
 import type { Availability, SuggestPayload } from "./types";
 
+// Allow pointing the frontend to a remote API instead of same-origin.
+const API_BASE = (import.meta.env.VITE_API_BASE as string | undefined) ?? "";
+
 export async function apiSuggest(payload: SuggestPayload): Promise<string[]> {
-  const r = await fetch("/api/suggest", {
+  const r = await fetch(`${API_BASE}/api/suggest`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload)
@@ -12,7 +15,9 @@ export async function apiSuggest(payload: SuggestPayload): Promise<string[]> {
 }
 
 export async function apiCheck(plate: string): Promise<Availability> {
-  const r = await fetch(`/api/check?plate=${encodeURIComponent(plate)}&state=CA`);
+  const r = await fetch(
+    `${API_BASE}/api/check?plate=${encodeURIComponent(plate)}&state=CA`
+  );
   if (!r.ok) throw new Error(`check failed: ${r.status}`);
   const j = await r.json();
   return j.availability as Availability;

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -2,6 +2,11 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
+  /**
+   * When hosted on GitHub Pages the app lives under
+   * `https://<user>.github.io/<repo>/`, so asset paths need the repo base.
+   */
+  base: "/PlateGenieCA/",
   plugins: [react()],
   server: {
     port: 5173,


### PR DESCRIPTION
## Summary
- configure Vite base path for GitHub Pages
- allow frontend to target external API via `VITE_API_BASE`
- document deployment and add web `.env.example`

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz; Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68abe32fb1308329b4352cad0b9bbd60