### PR TITLE
test: verify hero copy and gif

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,11 +1,16 @@
 import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { describe, it, expect } from 'vitest';
 import App from './App';
+import { COPY } from './copy';
 
 describe('App', () => {
-  it('renders heading', () => {
+  it('renders copy and hero image', () => {
     render(<App />);
-    const heading = screen.getByRole('heading', { name: /CA Plate Genie/i });
-    expect(heading).toBeDefined();
+    const heading = screen.getByRole('heading', { name: COPY.HERO.headline });
+    expect(heading).toBeInTheDocument();
+
+    const img = screen.getByRole('img', { name: /Driving genie/i });
+    expect(img).toHaveAttribute('src', '/CA-Plate-Genie.gif');
   });
 });


### PR DESCRIPTION
## Summary
- verify hero copy and GIF path using testing-library matchers

## Testing
- `npm --prefix web test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abee5833b48329a927f7f3624f20a4