### PR TITLE
fix: use base URL for genie gif

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -11,6 +11,9 @@ describe('App', () => {
     expect(heading).toBeInTheDocument();
 
     const img = screen.getByRole('img', { name: /Driving genie/i });
-    expect(img).toHaveAttribute('src', '/CA-Plate-Genie.gif');
+    expect(img).toHaveAttribute(
+      'src',
+      `${import.meta.env.BASE_URL}CA-Plate-Genie.gif`
+    );
   });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -74,7 +74,11 @@ export default function App() {
 
   return (
     <div className="container">
-      <img src="/CA-Plate-Genie.gif" alt="Driving genie" className="hero" />
+      <img
+        src={`${import.meta.env.BASE_URL}CA-Plate-Genie.gif`}
+        alt="Driving genie"
+        className="hero"
+      />
       <h1>{COPY.HERO.headline}</h1>
       <p><small className="hint">{COPY.HERO.subhead}</small></p>
 


### PR DESCRIPTION
## Summary
- load the hero GIF using `import.meta.env.BASE_URL` so it works when hosted from subpaths
- update tests to expect the new resolved path

## Testing
- `node --import tsx --test src/example.test.ts`
- `../node_modules/.bin/vitest run` *(fails: Cannot resolve module '@testing-library/jest-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68acce787b28832981ca49393aef829c